### PR TITLE
Build: Trim UDK Size

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -17,7 +17,7 @@ prompt() {
 
 updaterepo() {
   if [ ! -d "$2" ]; then
-    git clone --recursive "$1" -b "$3" --depth=1 "$2" || exit 1
+    git clone "$1" -b "$3" --depth=1 "$2" || exit 1
   fi
   pushd "$2" >/dev/null || exit 1
   git pull
@@ -29,6 +29,7 @@ updaterepo() {
       exit 1
     fi
   fi
+  git submodule update --init --recommend-shallow || exit 1
   popd >/dev/null || exit 1
 }
 


### PR DESCRIPTION
Closes https://github.com/acidanthera/bugtracker/issues/1119

UDK size jumped up massively in moving to v0.6.0. 

Had a close look at things and this PR sets things back to a more reasonable size.

# 1: Default Full Recursive
- Gets all SubModules recursively and fetches the full history of each SubModule
- Total SubModules = 14
- Total Download Size = 1.15 Gb
- Speed = Very Very Slow
- OpenCorePkg Build = Builds Cleanly

# 2: Scripted Full Recursive
- Gets all SubModules recursively but only fetches the current head for each SubModule
- Total SubModules = 14
- Total Download Size = 0.72 Gb
- Speed = Quite Fast
- OpenCorePkg Build = Builds Cleanly

# 3: Scripted Recursive (Depth 2)
- Gets primary SubModules (Depth 1) with each able to get next level SubModules (Depth 2) and only fetches the current head for each SubModule
- Total SubModules = 14 (Same as Setup 2 which turns out to only go 2 levels)
- Total Download Size = 0.72 Gb . (Same as Setup 2 which turns out to only go 2 levels)
- Speed = Quite Fast
- OpenCorePkg Build = Builds Cleanly

# 4: Scripted Recursive (Depth 1)
- Gets primary SubModules (Depth 1) only and only fetches the current head for each SubModule
- Total SubModules = 6
- Total Download Size = 0.41 Gb
- Speed = Fast
- OpenCorePkg Build = Builds Cleanly

# 5: Scripted Recursive (Depth 0)
- Skips SubModules altogether
- Total SubModules = 0
- Total Download Size = 0.11 Gb
- Speed = Very Very Fast
- OpenCorePkg Build = Builds Falis

# 4a: Scripted Recursive (Depth 1 - Brotli Only)

Obviously Setup 4 is the most optimal as the deeper level UDK Submodules are not used by the OpenCorePkg build.
Looking at the build messages, it appeared that OpenCorePkg seemed to only require Brotli. Testing this gave:
- Gets primary Brotli SubModules Only and only fetches the current head for each
- Total SubModules = 2
- Total Download Size = 0.15 Gb
- Speed = Very Fast
- OpenCorePkg Build = Builds Cleanly

# 4b: Scripted Recursive (Depth 1 - Brotli Only ... Once)
Looking at the two Brotli SubModules, it turns out they are exactly the same and pulled form the same location.
- submodule.MdeModulePkg/Library/BrotliCustomDecompressLib/brotli.url=**https://github.com/google/brotli**
- submodule.BaseTools/Source/C/BrotliCompress/brotli.url=**https://github.com/google/brotli**

So, adjusted to download once and copy across to the other location:
- Gets primary Brotli SubModules Only and only fetches the current head for this andc opies across to other location
- Total SubModules = 1
- Total Download Size = 0.13 Gb
- Speed = Very Very Fast
- OpenCorePkg Build = Builds Cleanly

# Summary
This PR implements Scenario 4b upon which OpenCorePkg builds cleanly.
Will look for a rational amendment to the build instructions in the docs  
