### PR TITLE
EfiBuild: Added extra archs support

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -441,10 +441,11 @@ if [ "$SKIP_BUILD" != "1" ]; then
     for toolchain in "${TOOLCHAINS[@]}" ; do
       for target in "${TARGETS[@]}" ; do
         if [ "$MODE" = "" ] || [ "$MODE" = "$target" ]; then
-          echo "Building ${SELFPKG_DIR}/${SELFPKG}.dsc for ${ARCHS[i]} in $target with ${toolchain} and flags $BUILD_STRING ..."
           if [ "${ARCHS_EXT[i]}" == "" ]; then
+            echo "Building ${SELFPKG_DIR}/${SELFPKG}.dsc for ${ARCHS[i]} in $target with ${toolchain} and flags $BUILD_STRING ..."
             buildme -a "${ARCHS[i]}" -b "$target" -t "${toolchain}" -p "${SELFPKG_DIR}/${SELFPKG}.dsc" "${BUILD_ARGUMENTS[@]}" || abortbuild
           else
+            echo "Building ${SELFPKG_DIR}/${SELFPKG}.dsc for ${ARCHS[i]} with extra arch ${ARCHS_EXT[i]} in $target with ${toolchain} and flags $BUILD_STRING ..."
             buildme -a "${ARCHS_EXT[i]}" -a "${ARCHS[i]}" -b "$target" -t "${toolchain}" -p "${SELFPKG_DIR}/${SELFPKG}.dsc" "${BUILD_ARGUMENTS[@]}" || abortbuild
           fi
           echo " - OK"

--- a/efibuild.sh
+++ b/efibuild.sh
@@ -437,12 +437,16 @@ fi
 
 if [ "$SKIP_BUILD" != "1" ]; then
   echo "Building..."
-  for arch in "${ARCHS[@]}" ; do
+  for i in "${!ARCHS[@]}" ; do
     for toolchain in "${TOOLCHAINS[@]}" ; do
       for target in "${TARGETS[@]}" ; do
         if [ "$MODE" = "" ] || [ "$MODE" = "$target" ]; then
-          echo "Building ${SELFPKG_DIR}/${SELFPKG}.dsc for $arch in $target with ${toolchain} and flags $BUILD_STRING ..."
-          buildme -a "$arch" -b "$target" -t "${toolchain}" -p "${SELFPKG_DIR}/${SELFPKG}.dsc" "${BUILD_ARGUMENTS[@]}" || abortbuild
+          echo "Building ${SELFPKG_DIR}/${SELFPKG}.dsc for ${ARCHS[i]} in $target with ${toolchain} and flags $BUILD_STRING ..."
+          if [ "${ARCHS_EXT[i]}" == "" ]; then
+            buildme -a "${ARCHS[i]}" -b "$target" -t "${toolchain}" -p "${SELFPKG_DIR}/${SELFPKG}.dsc" "${BUILD_ARGUMENTS[@]}" || abortbuild
+          else
+            buildme -a "${ARCHS_EXT[i]}" -a "${ARCHS[i]}" -b "$target" -t "${toolchain}" -p "${SELFPKG_DIR}/${SELFPKG}.dsc" "${BUILD_ARGUMENTS[@]}" || abortbuild
+          fi
           echo " - OK"
         fi
       done


### PR DESCRIPTION
Add ARCHS_EXT array-variable support, which gives ability to set additional arch for build.
For example, this feature may used to create 32-bit entrypoint for UefiPayloadPkg via specifying IA32 arch like:
`build -a IA32 -a X64 -p UefiPayloadPkg/UefiPayloadPkg.dsc ...`
ARCHS_EXT array is linked to ARCHS variable, so
```
ARCHS=('X64', 'IA32')
ARCHS_EXT=('IA32', '')
```
gives combinations:
1) -a IA32 -a X64
2) -a X64
