### PR TITLE
EfiBuild: Remove duplicated CRLF check

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -22,7 +22,7 @@ updaterepo() {
   pushd "$2" >/dev/null || exit 1
   git pull --rebase --autostash
   if [ "$2" != "UDK" ] && [ "$(unamer)" != "Windows" ]; then
-    sym=$(find . -not -type d -exec file "{}" ";" | grep CRLF)
+    sym=$(find . -type f -exec file "{}" ";" | grep CRLF)
     if [ "${sym}" != "" ]; then
       echo "Repository $1 named $2 contains CRLF line endings"
       echo "$sym"

--- a/efibuild.sh
+++ b/efibuild.sh
@@ -321,16 +321,9 @@ if [ ! -d "Binaries" ]; then
   mkdir Binaries || exit 1
 fi
 
-if [ ! -f UDK/UDK.ready ]; then
-  rm -rf UDK
-
-  if [ "$(unamer)" != "Windows" ]; then
-    sym=$(find . -not -type d -exec file "{}" ";" | grep CRLF)
-    if [ "${sym}" != "" ]; then
-      echo "Error: the following files in the repository CRLF line endings:"
-      echo "$sym"
-      exit 1
-    fi
+if [ -d UDK ]; then
+  if [ ! -f UDK/UDK.ready ]; then
+    rm -rf UDK
   fi
 fi
 


### PR DESCRIPTION
CRLF check already present in updaterepo() procedure, no need to double run this script-part. Also add additional check of UDK folder existence.