### PR TITLE
ci-bootstrap: Add check for plist integer type

### DIFF
--- a/ci-bootstrap.sh
+++ b/ci-bootstrap.sh
@@ -107,9 +107,7 @@ ret=0
 while read -r line; do
   if [ "$(grep -z '<real>(.\|\s)*</real>' "${line}")" != "" ]; then
     echo "Please change <real>*</real> back to <integer>*</integer> in ${line}"
-    # FIXME: Find better ways to patch the files
-    perl -pi -e 's/<real>/<integer>/g' "${line}"
-    perl -pi -e 's/<\/real>/<\/integer>/g' "${line}"
+    sed -i '.bak' -E 's/<(\/)?real>/<\1integer>/g' "${line}"
     ret=1
   fi
 done < <(find . -type f -name '*.plist')

--- a/ci-bootstrap.sh
+++ b/ci-bootstrap.sh
@@ -105,7 +105,7 @@ fi
 colored_text "plist integer type check"
 ret=0
 while read -r line; do
-  if [ "$(grep '<real>.*</real>' "${line}")" != "" ]; then
+  if [ "$(grep -z '<real>(.\|\s)*</real>' "${line}")" != "" ]; then
     echo "Please change <real>*</real> back to <integer>*</integer> in ${line}"
     # FIXME: Find better ways to patch the files
     perl -pi -e 's/<real>/<integer>/g' "${line}"

--- a/ci-bootstrap.sh
+++ b/ci-bootstrap.sh
@@ -101,3 +101,16 @@ else
   colored_text "gcc version"
   gcc --version
 fi
+
+colored_text "plist integer type check"
+ret=0
+while read -r line; do
+  if [ "$(grep '<real>.*</real>' "${line}")" != "" ]; then
+    echo "Please change <real>*</real> back to <integer>*</integer> in ${line}"
+    ret=1
+  fi
+done < <(find . -type f -name '*.plist')
+
+if [ "${ret}" != 0 ]; then
+  abort "Please fix integer type problems for the plist above"
+fi

--- a/ci-bootstrap.sh
+++ b/ci-bootstrap.sh
@@ -107,10 +107,14 @@ ret=0
 while read -r line; do
   if [ "$(grep '<real>.*</real>' "${line}")" != "" ]; then
     echo "Please change <real>*</real> back to <integer>*</integer> in ${line}"
+    # FIXME: Find better ways to patch the files
+    perl -pi -e 's/<real>/<integer>/g' "${line}"
+    perl -pi -e 's/<\/real>/<\/integer>/g' "${line}"
     ret=1
   fi
 done < <(find . -type f -name '*.plist')
 
 if [ "${ret}" != 0 ]; then
+  git diff > plist-int.diff
   abort "Please fix integer type problems for the plist above"
 fi


### PR DESCRIPTION
TODO:
- [ ] repositories should add an upload artifact step to the workflow

Recent versions of Xcode constantly change plist type integer from `<integer>*</integer>` to `<real>*</real>` with values supposedly more than or equal to four digits (i.e. `1000`), which caused kernel panics. One example includes https://github.com/acidanthera/bugtracker/issues/2070#issuecomment-1174173360.

This PR checks against `<real>*</real>` in all plist files in our projects; CI bootstrap script will exit with error code if found.

EDIT - I confirm that this PR is working correctly; see https://github.com/acidanthera/AppleALC/runs/7186678355

EDIT 2 - Off-topic: This bug could be fixed with Xcode 14, and we wish it was real.