### PR TITLE
efibuild: Adds support for plain string in build arguments

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -13,6 +13,16 @@ if [ "$OFFLINE_MODE" = "" ]; then
   OFFLINE_MODE=0
 fi
 
+is_array()
+{
+    # Detects if argument is an array, returns 1 on sucess, 0 otherwise
+    [ -z "$1" ] && return 0
+    if [ -n "$BASH" ]; then
+      declare -p "${1}" 2> /dev/null | grep 'declare \-a' >/dev/null && return 1
+    fi
+    return 0
+}
+
 prompt() {
   echo "$1"
   if [ "$FORCE_INSTALL" != "1" ]; then
@@ -267,11 +277,31 @@ if [ "$RELPKG" = "" ]; then
   RELPKG="$SELFPKG"
 fi
 
-if [ "$ARCHS" = "" ]; then
+if [[ ! $(is_array ARCHS) ]]; then
+  IFS=', ' read -r -a ARCHS <<< "$ARCHS"
+fi
+
+if [[ ! $(is_array ARCHS_EXT) ]]; then
+  IFS=', ' read -r -a ARCHS_EXT <<< "$ARCHS_EXT"
+fi
+
+if [[ ! $(is_array TOOLCHAINS) ]]; then
+  IFS=', ' read -r -a TOOLCHAINS <<< "$TOOLCHAINS"
+fi
+
+if [[ ! $(is_array TARGETS) ]]; then
+  IFS=', ' read -r -a TARGETS <<< "$TARGETS"
+fi
+
+if [[ ! $(is_array RTARGETS) ]]; then
+  IFS=', ' read -r -a RTARGETS <<< "$RTARGETS"
+fi
+
+if [ "${ARCHS[*]}" = "" ]; then
   ARCHS=('X64')
 fi
 
-if [ "$TOOLCHAINS" = "" ]; then
+if [ "${TOOLCHAINS[*]}" = "" ]; then
   if [ "$(unamer)" = "Darwin" ]; then
     TOOLCHAINS=('XCODE5')
   elif [ "$(unamer)" = "Windows" ]; then
@@ -281,7 +311,7 @@ if [ "$TOOLCHAINS" = "" ]; then
   fi
 fi
 
-if [ "$TARGETS" = "" ]; then
+if [ "${TARGETS[*]}" = "" ]; then
   TARGETS=('DEBUG' 'RELEASE' 'NOOPT')
 elif [ "${RTARGETS[*]}" = "" ]; then
   RTARGETS=("${TARGETS[@]}")

--- a/efibuild.sh
+++ b/efibuild.sh
@@ -15,7 +15,7 @@ fi
 
 is_array()
 {
-    # Detects if argument is an array, returns 1 on sucess, 0 otherwise
+    # Detects if argument is an array, returns 1 on success, 0 otherwise
     [ -z "$1" ] && return 0
     if [ -n "$BASH" ]; then
       declare -p "${1}" 2> /dev/null | grep 'declare \-a' >/dev/null && return 1


### PR DESCRIPTION
Some environments like docker don't support bash arrays, so we need to use string arguments for such cases