### PR TITLE
efibuild: Add support for DISCARD_SUBMODULES

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -53,12 +53,14 @@ updaterepo() {
       exit 1
     fi
   fi
-  if [ "$2" = "UDK" ] && [ "$DISCARD_SUBMODULES" != "" ]; then
+  if [ "$2" = "UDK" ] && [ "$DISCARD_SUBMODULES" != "" ] && [ ! -f submodules.ready ]; then
     setcommitauthor
     for module_to_discard in "${DISCARD_SUBMODULES[@]}" ; do
+      git submodule deinit "${module_to_discard}"
       git rm "${module_to_discard}"
     done
     git commit -m "Discarded submodules"
+    touch submodules.ready
   fi
   git submodule update --init --recommend-shallow || exit 1
   popd >/dev/null || exit 1

--- a/efibuild.sh
+++ b/efibuild.sh
@@ -33,6 +33,12 @@ prompt() {
   fi
 }
 
+setcommitauthor() {
+  git config user.name ocbuild
+  git config user.email ocbuild@acidanthera.local
+  git config commit.gpgsign false
+}
+
 updaterepo() {
   if [ ! -d "$2" ]; then
     git clone "$1" -b "$3" --depth=1 "$2" || exit 1
@@ -46,6 +52,13 @@ updaterepo() {
       echo "$sym"
       exit 1
     fi
+  fi
+  if [ "$2" = "UDK" ] && [ "$DISCARD_SUBMODULES" != "" ]; then
+    setcommitauthor
+    for module_to_discard in "${DISCARD_SUBMODULES[@]}" ; do
+      git rm "${module_to_discard}"
+    done
+    git commit -m "Discarded submodules"
   fi
   git submodule update --init --recommend-shallow || exit 1
   popd >/dev/null || exit 1
@@ -393,9 +406,7 @@ fi
 if [ "$NEW_BUILDSYSTEM" != "1" ]; then
   if [ -d ../Patches ]; then
     if [ ! -f patches.ready ]; then
-      git config user.name ocbuild
-      git config user.email ocbuild@acidanthera.local
-      git config commit.gpgsign false
+      setcommitauthor
       for i in ../Patches/* ; do
         git apply --ignore-whitespace "$i" || exit 1
         git add .

--- a/efibuild.sh
+++ b/efibuild.sh
@@ -56,7 +56,6 @@ updaterepo() {
   if [ "$2" = "UDK" ] && [ "$DISCARD_SUBMODULES" != "" ] && [ ! -f submodules.ready ]; then
     setcommitauthor
     for module_to_discard in "${DISCARD_SUBMODULES[@]}" ; do
-      git submodule deinit "${module_to_discard}"
       git rm "${module_to_discard}"
     done
     git commit -m "Discarded submodules"


### PR DESCRIPTION
This is faster to build than using DISCARD_PACKAGES since OpenCorePkg does not need to be cloned (which is relatively slow) then deleted. To [implement in OpenCore](https://github.com/acidanthera/OpenCorePkg/pull/501) requires changing build_duet.tool and build_oc.tool to set and export DISCARD_SUBMODULES instead of DISCARD_PACKAGES. (Not sure if there are other projects that can be updated too, though DISCARD_PACKAGES is still supported.)

[Requires new-enough git to work](https://stackoverflow.com/a/1260982/795690), though I believe that is not an issue here - unless we perhaps need to support building on user-owned machines too old to have this?