### PR TITLE
efibuild: Show repo commit after initial clone

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -42,8 +42,11 @@ setcommitauthor() {
 updaterepo() {
   if [ ! -d "$2" ]; then
     git clone "$1" -b "$3" --depth=1 "$2" || exit 1
+    pushd "$2" >/dev/null || exit 1
+    echo "Cloned ${1} at commit $(git rev-parse --short=8 HEAD)."
+  else
+    pushd "$2" >/dev/null || exit 1
   fi
-  pushd "$2" >/dev/null || exit 1
   git pull --rebase --autostash
   if [ "$2" != "UDK" ] && [ "$(unamer)" != "Windows" ]; then
     sym=$(find . -not -type d -not -path "./coreboot/*" -not -path "./UDK/*" -exec file "{}" ";" | grep CRLF)


### PR DESCRIPTION
Should be a reasonably clean way to show in the Build actions log which audk commit was used. This info does not persist beyond a certain time, but I think useful to have in the log anyway?

Example output:

```
...
Resolving deltas: 100% (3348/3348), done.
Updating files: 100% (9697/9697), done.
Cloned https://github.com/acidanthera/audk at commit c85c584c.
Already up to date.
rm 'OpenCorePkg'
[master 8cd05d0] Discarded submodules
...
```