### PR TITLE
efibuild: Allow for manual control of audk commit

### DIFF
--- a/efibuild.sh
+++ b/efibuild.sh
@@ -41,13 +41,22 @@ setcommitauthor() {
 
 updaterepo() {
   if [ ! -d "$2" ]; then
-    git clone "$1" -b "$3" --depth=1 "$2" || exit 1
+    if [ "$4" != "" ]; then
+      git clone "$1" -b "$3" "$2" || exit 1
+    else
+      git clone "$1" -b "$3" --depth=1 "$2" || exit 1
+    fi
     pushd "$2" >/dev/null || exit 1
+    if [ "$4" != "" ]; then
+      git reset --hard "$4"
+    fi
     echo "Cloned ${1} at commit $(git rev-parse --short=8 HEAD)."
   else
     pushd "$2" >/dev/null || exit 1
   fi
-  git pull --rebase --autostash
+  if [ "$4" == "" ]; then
+    git pull --rebase --autostash
+  fi
   if [ "$2" != "UDK" ] && [ "$(unamer)" != "Windows" ]; then
     sym=$(find . -not -type d -not -path "./coreboot/*" -not -path "./UDK/*" -exec file "{}" ";" | grep CRLF)
     if [ "${sym}" != "" ]; then
@@ -391,7 +400,7 @@ fi
 
 if [ "$NEW_BUILDSYSTEM" != "1" ]; then
   if [ "$OFFLINE_MODE" != "1" ]; then
-    updaterepo "https://github.com/acidanthera/audk" UDK master || exit 1
+    updaterepo "https://github.com/acidanthera/audk" UDK master "${AUDK}" || exit 1
   else
     echo "Working in offline mode. Skip UDK update"
   fi


### PR DESCRIPTION
Hi @vit9696 -

I don't reallly like what I've done here, however it is very useful!

For instance, in investigating https://github.com/acidanthera/bugtracker/issues/2507#issuecomment-3390818732, I was able to run:

```
rm -rf UDK
AUDK=f39c4bc76a5bc4904159996dd752ac4bb4601a72 ./build_duet.tool 
AUDK=f39c4bc76a5bc4904159996dd752ac4bb4601a72 ./build_oc.tool
```

to rebuild using https://github.com/acidanthera/audk/commit/f39c4bc76a5bc4904159996dd752ac4bb4601a72, and then

```
rm -rf UDK
AUDK=21e77e TARGETS=RELEASE ARCHS=X64 ./build_duet.tool 
AUDK=21e77e TARGETS=RELEASE ARCHS=X64 ./build_oc.tool --skip-tests
```

for quick rebuild, RELEASE only, using https://github.com/acidanthera/audk/commit/21e77e0659fc70c8f34a0d267df53ba3cb9346ca.